### PR TITLE
Add Order, Address, and Credit Card models

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,5 @@
+class Address < ApplicationRecord
+  has_one :order
+
+  validates :line_1, :city, :state, :zip, :country, presence: true
+end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -1,0 +1,9 @@
+class CreditCard < ApplicationRecord
+  has_one :order
+
+  validates :last4, presence: true, length: { is: 4 }, numericality: { only_integer: true }
+  validates :brand, presence: true
+  validates :exp_month, presence: true, inclusion: { in: 1..12 }
+  validates :exp_year, presence: true
+  validates :token, presence: true
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,7 @@
 class Order < ApplicationRecord
+  belongs_to :address, dependent: :destroy
+  belongs_to :credit_card, dependent: :destroy
+
   has_many :order_products, dependent: :destroy
 
   validates :total_price_cents, presence: true

--- a/db/migrate/20251211200137_create_addresses.rb
+++ b/db/migrate/20251211200137_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :addresses do |t|
+      t.string :line_1
+      t.string :line_2
+      t.string :city
+      t.string :state
+      t.string :zip
+      t.string :country
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251211200138_create_credit_cards.rb
+++ b/db/migrate/20251211200138_create_credit_cards.rb
@@ -1,0 +1,13 @@
+class CreateCreditCards < ActiveRecord::Migration[8.0]
+  def change
+    create_table :credit_cards do |t|
+      t.string :last4
+      t.string :brand
+      t.integer :exp_month
+      t.integer :exp_year
+      t.string :token
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251211200219_add_address_and_credit_card_references_to_orders.rb
+++ b/db/migrate/20251211200219_add_address_and_credit_card_references_to_orders.rb
@@ -1,0 +1,8 @@
+class AddAddressAndCreditCardReferencesToOrders < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do # Orders are created along this transaction
+      add_reference :orders, :address, null: false, foreign_key: true
+      add_reference :orders, :credit_card, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_11_172610) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_11_200219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "line_1"
+    t.string "line_2"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.string "country"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "credit_cards", force: :cascade do |t|
+    t.string "last4"
+    t.string "brand"
+    t.integer "exp_month"
+    t.integer "exp_year"
+    t.string "token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "order_products", force: :cascade do |t|
     t.bigint "order_id", null: false
@@ -33,6 +54,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_11_172610) do
     t.string "total_price_currency"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "address_id", null: false
+    t.bigint "credit_card_id", null: false
+    t.index ["address_id"], name: "index_orders_on_address_id"
+    t.index ["credit_card_id"], name: "index_orders_on_credit_card_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -65,6 +90,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_11_172610) do
 
   add_foreign_key "order_products", "orders"
   add_foreign_key "order_products", "products"
+  add_foreign_key "orders", "addresses"
+  add_foreign_key "orders", "credit_cards"
   add_foreign_key "shopping_basket_products", "products"
   add_foreign_key "shopping_basket_products", "shopping_baskets"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :address do
+    line_1 { Faker::Address.street_address }
+    city { Faker::Address.city }
+    state { Faker::Address.state }
+    zip { Faker::Address.zip_code }
+    country { Faker::Address.country }
+  end
+end

--- a/spec/factories/credit_cards.rb
+++ b/spec/factories/credit_cards.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :credit_card do
+    last4 { Faker::Number.number(digits: 4).to_s }
+    brand { [ "Visa", "MasterCard", "Amex" ].sample }
+    exp_month { Faker::Number.between(from: 1, to: 12) }
+    exp_year { Faker::Number.between(from: Date.today.year + 1, to: Date.today.year + 5) }
+    token { "tok_success" }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :order do
+    credit_card
+    address
+
     email { Faker::Internet.email }
 
     total_price_cents { Faker::Number.between(from: 10_00, to: 500_00) }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  subject { build(:address) }
+
+  describe "Associations" do
+    it { should have_one(:order) }
+  end
+
+  describe "Validations" do
+    it { should validate_presence_of(:line_1) }
+    it { should validate_presence_of(:city) }
+    it { should validate_presence_of(:state) }
+    it { should validate_presence_of(:zip) }
+    it { should validate_presence_of(:country) }
+  end
+end

--- a/spec/models/credit_card_spec.rb
+++ b/spec/models/credit_card_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe CreditCard, type: :model do
+  subject { build(:credit_card) }
+
+  describe "Associations" do
+    it { should have_one(:order) }
+  end
+
+  describe "Validations" do
+    it { should validate_presence_of(:brand) }
+    it { should validate_presence_of(:token) }
+
+    it { should validate_presence_of(:last4) }
+    it { should validate_length_of(:last4).is_equal_to(4) }
+    it { should validate_numericality_of(:last4).only_integer }
+
+    it { should validate_presence_of(:exp_month) }
+    it { should validate_presence_of(:exp_year) }
+    it { should validate_inclusion_of(:exp_month).in_range(1..12) }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Order, type: :model do
   subject { build(:order) }
 
   describe "Associations" do
+    it { should belong_to(:address).dependent(:destroy) }
+    it { should belong_to(:credit_card).dependent(:destroy) }
     it { should have_many(:order_products).dependent(:destroy) }
   end
 


### PR DESCRIPTION
## Description

This PR adds `Address` and `CreditCard` models, integrating them with the `Order` model to associate completed orders with billing/shipping addresses and stored credit card tokens.

## Key Changes

- Create `Address` model and table with `line_1`, `line_2`, `city`, `state`, `zip`, `country`, validations, and `has_one :order`.
- Create `CreditCard` model and table with `last4`, `brand`, `exp_month`, `exp_year`, `token`, validations, and `has_one :order`.
- Update `Order` to `belongs_to :address` and `belongs_to :credit_card`, with migration for foreign keys.
- Add factories for `address` and `credit_card`, integrate into `order`, and add model specs for associations and validations. 