### PR TITLE
Add Redis and ETag caching for Products and Shopping Basket endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "puma", ">= 5.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,9 +181,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
-    oj (3.16.14)
+    oj (3.16.13)
       bigdecimal (>= 3.0)
-    pagy (43.2.9)
+      ostruct (>= 0.2)
+    ostruct (0.6.3)
+    pagy (43.2.0)
       json
       yaml
     parallel (1.27.0)
@@ -257,6 +259,10 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.26.2)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -313,7 +319,7 @@ GEM
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
     stringio (3.1.7)
-    strong_migrations (2.5.2)
+    strong_migrations (2.5.1)
       activerecord (>= 7.1)
     thor (1.4.0)
     timeout (0.4.3)
@@ -362,6 +368,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 8.0.0)
+  redis (>= 4.0.1)
   rspec-rails (~> 6.1)
   rspec-uuid (~> 0.6.0)
   rubocop-rails-omakase

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ bundle exec rspec
 COVERAGE=true bundle exec rspec
 ```
 
+### Development Caching
+
+```bash
+# Enable/Disable caching in development (Required to test Redis caching behavior)
+bundle exec rails dev:cache
+```
+
 ---
 
 ## ⚖️ Trade-offs & Future Roadmap

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -2,21 +2,42 @@ module Api
   module V1
     class ProductsController < BaseController
       def index
-        pagy_page = index_params[:page].present? ? index_params[:page].to_i : 1
-        @pagy, @records = pagy(
-          Product.order(id: :asc),
-          page: pagy_page,
-        )
-        render status: :ok,
-          json: PaginationBlueprint.render(
+        # 1. Prepare query and paginate (lazy load)
+        pagy_page = [ index_params[:page].to_i, 1 ].max
+        products_query = Product.order(id: :asc)
+        @pagy, @records = pagy(products_query, page: pagy_page)
+
+        # 2. Derive cache versions (avoids full serialization if stale)
+        # Triggers a fast `SELECT MAX(updated_at)` specific to this page window.
+        max_updated_at = @records.maximum(:updated_at)
+
+        # 3. HTTP Cache check (returns 304 if client matches ETag/Last-Modified)
+        if stale?(etag: @records, last_modified: max_updated_at)
+
+          # 4. Server Cache
+          cache_key = [ "products_index", pagy_page, max_updated_at ]
+
+          data = Rails.cache.fetch(cache_key) do
+            PaginationBlueprint.render_as_hash(
               @pagy,
               records: ProductBlueprint.render_as_hash(@records)
             )
+          end
+
+          render status: :ok, json: data
+        end
       end
 
       def show
         product = Product.find(params[:id])
-        render status: :ok, json: ProductBlueprint.render(product)
+
+        if stale?(product)
+          product_blueprint = Rails.cache.fetch(product.cache_key_with_version) do
+            ProductBlueprint.render_as_hash(product)
+          end
+
+          render status: :ok, json: product_blueprint
+        end
       end
 
       private

--- a/app/controllers/api/v1/shopping_baskets/checkouts_controller.rb
+++ b/app/controllers/api/v1/shopping_baskets/checkouts_controller.rb
@@ -13,7 +13,7 @@ module Api
           )
 
           order_with_products = Order.with_associations.find(order.id)
-          render json: OrderBlueprint.render(order_with_products), status: :created
+          render json: OrderBlueprint.render_as_hash(order_with_products), status: :created
         end
 
         def checkout_params

--- a/app/controllers/api/v1/shopping_baskets/shopping_basket_products_controller.rb
+++ b/app/controllers/api/v1/shopping_baskets/shopping_basket_products_controller.rb
@@ -11,7 +11,7 @@ module Api
             quantity: product_params[:quantity]
           )
 
-          render json: ShoppingBasketBlueprint.render(updated_basket), status: :created
+          render json: ShoppingBasketBlueprint.render_as_hash(updated_basket), status: :created
         end
 
         private

--- a/app/controllers/api/v1/shopping_baskets_controller.rb
+++ b/app/controllers/api/v1/shopping_baskets_controller.rb
@@ -4,7 +4,20 @@ module Api
       before_action :set_shopping_basket, only: :show
 
       def show
-        render status: :ok, json: ShoppingBasketBlueprint.render(current_shopping_basket)
+        # Calculate cache key including the max product updated_at, if it is nil, it works well too.
+        # This ensures the cache is invalidated if the basket changes OR if a product's stock updates.
+        stale_key = [ current_shopping_basket, current_shopping_basket.products_last_updated_at ]
+        cache_key = [ current_shopping_basket.cache_key_with_version,
+          current_shopping_basket.products_last_updated_at ]
+
+        # Fetch data or generate it
+        if stale?(etag: stale_key)
+          basket_blueprint = Rails.cache.fetch(cache_key) do
+            ShoppingBasketBlueprint.render_as_hash(current_shopping_basket)
+          end
+
+          render status: :ok, json: basket_blueprint
+        end
       end
     end
   end

--- a/app/models/shopping_basket.rb
+++ b/app/models/shopping_basket.rb
@@ -14,6 +14,10 @@ class ShoppingBasket < ApplicationRecord
     shopping_basket_products.sum(Money.new(0), &:total_price)
   end
 
+  def products_last_updated_at
+    shopping_basket_products.map { |p| p.product.updated_at }.max
+  end
+
   private
 
   def set_uuid

--- a/app/models/shopping_basket_product.rb
+++ b/app/models/shopping_basket_product.rb
@@ -1,5 +1,5 @@
 class ShoppingBasketProduct < ApplicationRecord
-  belongs_to :shopping_basket
+  belongs_to :shopping_basket, touch: true
   belongs_to :product
 
   validates :product_id,

--- a/spec/requests/api/caching_spec.rb
+++ b/spec/requests/api/caching_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe "Caching", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  # Shared examples to test ETag and Last-Modified headers
+  shared_examples "an endpoint with ETag support" do |path_proc|
+    it "returns ETag and Last-Modified headers" do
+      get path, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['ETag']).to be_present
+      expect(response.headers['Last-Modified']).to be_present
+    end
+
+    it "returns 304 Not Modified when client sends valid cache headers" do
+      # 1. First request to get headers
+      get path, headers: headers
+      etag = response.headers['ETag']
+      last_modified = response.headers['Last-Modified']
+
+      # 2. Second request with conditional headers
+      get path, headers: headers.merge({ 'If-None-Match' => etag, 'If-Modified-Since' => last_modified })
+      expect(response).to have_http_status(:not_modified)
+    end
+  end
+
+  describe "api/v1/products" do
+    let!(:product) { create(:product, updated_at: 1.hour.ago) }
+    let(:headers) { {} }
+
+    describe "GET /api/v1/products" do
+      let(:path) { "/api/v1/products" }
+      it_behaves_like "an endpoint with ETag support"
+    end
+
+    describe "GET /api/v1/products/:id" do
+      let(:path) { "/api/v1/products/#{product.id}" }
+      it_behaves_like "an endpoint with ETag support"
+    end
+  end
+
+  describe "api/v1/shopping_basket" do
+    let(:shopping_basket) { create(:shopping_basket) }
+    let(:headers) { { "Authorization" => "Bearer #{shopping_basket.uuid}" } }
+    let!(:product_for_basket) { create(:product, stock: 10, updated_at: 1.hour.ago) }
+
+    before do
+      create(:shopping_basket_product, shopping_basket: shopping_basket, product: product_for_basket, quantity: 1)
+    end
+
+    it "changes the response ETag (invalidating cache) when a product is updated" do
+      # 1. Initial Request
+      get "/api/v1/shopping_basket", headers: headers
+      initial_etag = response.headers['ETag']
+
+      # 2. Modify state (Simulate update after some time)
+      travel 10.minutes do
+        product_for_basket.touch # Updates updated_at
+
+        # 3. Request again
+        get "/api/v1/shopping_basket", headers: headers
+        new_etag = response.headers['ETag']
+
+        expect(new_etag).not_to eq(initial_etag)
+        expect(response).to have_http_status(:ok) # Should be 200 (fresh content), not 304
+      end
+    end
+  end
+end

--- a/spec/requests/api/products_spec.rb
+++ b/spec/requests/api/products_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe "Api::Products", type: :request do
     it "delegates serialization to ProductBlueprint and PaginationBlueprint" do
       # We just want to spy on calls, not change behavior
       allow(ProductBlueprint).to receive(:render_as_hash).and_call_original
-      allow(PaginationBlueprint).to receive(:render).and_call_original
+      allow(PaginationBlueprint).to receive(:render_as_hash).and_call_original
 
       get "/api/v1/products", params: { page: 1 }
 
       expect(ProductBlueprint).to have_received(:render_as_hash)
 
-      expect(PaginationBlueprint).to have_received(:render)
+      expect(PaginationBlueprint).to have_received(:render_as_hash)
     end
 
     it "returns HTTP 200 and correct pagination metadata structure" do


### PR DESCRIPTION
## Summary
Implements a two-layer caching strategy to optimize read-heavy endpoints, using HTTP Caching (ETag) for bandwidth savings and Fragment Caching (Redis) to reduce serialization overhead.

## Key Changes
- **Infrastructure:** Added Redis service via Docker and configured `:redis_cache_store`.
- **HTTP Layer:** Implemented `stale?` checks to allow `304 Not Modified` responses.
- **App Layer:** Wrapped Blueprinter serialization in `Rails.cache.fetch` with composite keys.
- **Optimization:** Switched to `.render_as_hash` to prevent double JSON encoding caused by `Rails.cache`.
- **Logic:** Added `products_last_updated_at` to `ShoppingBasket` to invalidate cache when included products change (stock/price updates).
- **Refactor:** Switched serialization to Blueprint.render_as_hash across all models so render json: receives a Hash (avoids accidental double-encoding from render returning a JSON string) and keeps caching/response handling consistent.

## Testing
- **Specs:** Added `spec/requests/api/caching_spec.rb` covering ETag presence, 304 responses, and cache invalidation.
- **Manual:** Run `rails dev:cache` and verify headers on endpoints.