### PR TITLE
Move Checkout to a background job

### DIFF
--- a/app/controllers/api/v2/shopping_baskets/checkouts_controller.rb
+++ b/app/controllers/api/v2/shopping_baskets/checkouts_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  module V2
+    module ShoppingBaskets
+      class CheckoutsController < BaseController
+        before_action :ensure_shopping_basket, only: [ :create ]
+
+        def create
+          CheckoutOrderJob.perform_later(
+            shopping_basket_id: current_shopping_basket.id,
+            email: checkout_params[:email],
+            payment_token: checkout_params[:payment_token],
+            address_params: address_params.to_h
+          )
+
+          render json: { message: "Checkout processing started" }, status: :accepted
+        end
+
+        def checkout_params
+          params.permit(:payment_token, :email)
+        end
+
+        def address_params
+          params.require(:address).permit(:line_1, :line_2, :city, :state, :zip, :country)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/checkout_order_job.rb
+++ b/app/jobs/checkout_order_job.rb
@@ -1,0 +1,20 @@
+class CheckoutOrderJob < ApplicationJob
+  queue_as :default
+
+  def perform(shopping_basket_id:, email:, payment_token:, address_params:)
+    shopping_basket = ShoppingBasket.find(shopping_basket_id)
+
+    ::ShoppingBaskets::CheckoutOrderService.call(
+      shopping_basket: shopping_basket,
+      email: email,
+      payment_token: payment_token,
+      address_params: address_params
+    )
+  rescue ::ShoppingBaskets::CheckoutOrderService::EmptyBasketError => e
+    Rails.logger.error("CheckoutOrderJob failed: #{e.message} for basket #{shopping_basket_id}")
+    raise # Re-raise to allow retry or dead letter queue handling
+  rescue ::ShoppingBaskets::CheckoutOrderService::PaymentError => e
+    Rails.logger.error("CheckoutOrderJob payment failed: #{e.message} for basket #{shopping_basket_id}")
+    raise # Re-raise to allow retry or dead letter queue handling
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,10 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       resources :products, only: [ :index, :show ]
+      resource :shopping_basket, only: [ :show ] do
+        resources :products, only: [ :create ], controller: "shopping_baskets/shopping_basket_products"
+        resource :checkout, only: [ :create ], controller: "shopping_baskets/checkouts"
+      end
     end
   end
 

--- a/spec/jobs/checkout_order_job_spec.rb
+++ b/spec/jobs/checkout_order_job_spec.rb
@@ -1,0 +1,195 @@
+require 'rails_helper'
+
+RSpec.describe CheckoutOrderJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:basket) { create(:shopping_basket) }
+  let(:product) { create(:product, stock: 10, price_cents: 10_00) }
+  let(:email) { "test@example.com" }
+  let(:payment_token) { "tok_success" }
+  let(:address_params) do
+    {
+      "line_1" => "123 Calle Falsa",
+      "line_2" => "Apt 4",
+      "city" => "Montevideo",
+      "state" => "Montevideo",
+      "zip" => "11300",
+      "country" => "UY"
+    }
+  end
+
+  before do
+    create(:shopping_basket_product, shopping_basket: basket, product: product, quantity: 2)
+  end
+
+  describe "queue configuration" do
+    it "is queued to the default queue" do
+      expect(described_class.queue_name).to eq("default")
+    end
+  end
+
+  describe "job enqueueing" do
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
+    it "can be enqueued with perform_later" do
+      expect {
+        described_class.perform_later(
+          shopping_basket_id: basket.id,
+          email: email,
+          payment_token: payment_token,
+          address_params: address_params
+        )
+      }.to have_enqueued_job(CheckoutOrderJob)
+    end
+
+    it "enqueues with correct arguments" do
+      expect {
+        described_class.perform_later(
+          shopping_basket_id: basket.id,
+          email: email,
+          payment_token: payment_token,
+          address_params: address_params
+        )
+      }.to have_enqueued_job(CheckoutOrderJob).with(
+        shopping_basket_id: basket.id,
+        email: email,
+        payment_token: payment_token,
+        address_params: address_params
+      )
+    end
+  end
+
+  describe "#perform" do
+    context "with valid parameters" do
+      it "calls CheckoutOrderService with correct parameters" do
+        expect(ShoppingBaskets::CheckoutOrderService).to receive(:call).with(
+          shopping_basket: basket,
+          email: email,
+          payment_token: payment_token,
+          address_params: address_params
+        ).and_return(double(id: 1))
+
+        described_class.perform_now(
+          shopping_basket_id: basket.id,
+          email: email,
+          payment_token: payment_token,
+          address_params: address_params
+        )
+      end
+
+      it "creates an order when service succeeds" do
+        expect {
+          described_class.perform_now(
+            shopping_basket_id: basket.id,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        }.to change(Order, :count).by(1)
+      end
+    end
+
+    context "when shopping basket does not exist" do
+      it "raises ActiveRecord::RecordNotFound" do
+        expect {
+          described_class.perform_now(
+            shopping_basket_id: 99999,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "does not call CheckoutOrderService when basket is not found" do
+        expect(ShoppingBaskets::CheckoutOrderService).not_to receive(:call)
+
+        expect {
+          described_class.perform_now(
+            shopping_basket_id: 99999,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when checkout fails with EmptyBasketError" do
+      before do
+        allow(ShoppingBaskets::CheckoutOrderService).to receive(:call)
+          .and_raise(ShoppingBaskets::CheckoutOrderService::EmptyBasketError.new("Basket is empty"))
+      end
+
+      it "logs the error and re-raises" do
+        allow(Rails.logger).to receive(:error)
+        expect {
+          described_class.perform_now(
+            shopping_basket_id: basket.id,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        }.to raise_error(ShoppingBaskets::CheckoutOrderService::EmptyBasketError, "Basket is empty")
+        expect(Rails.logger).to have_received(:error).with(/CheckoutOrderJob failed: Basket is empty/)
+      end
+    end
+
+    context "when checkout fails with PaymentError" do
+      before do
+        allow(ShoppingBaskets::CheckoutOrderService).to receive(:call)
+          .and_raise(ShoppingBaskets::CheckoutOrderService::PaymentError.new("Insufficient funds"))
+      end
+
+      it "logs the error and re-raises" do
+        allow(Rails.logger).to receive(:error)
+        expect {
+          described_class.perform_now(
+            shopping_basket_id: basket.id,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        }.to raise_error(ShoppingBaskets::CheckoutOrderService::PaymentError, "Insufficient funds")
+        expect(Rails.logger).to have_received(:error).with(/CheckoutOrderJob payment failed: Insufficient funds/)
+      end
+    end
+
+    context "when service raises an unexpected error" do
+      before do
+        allow(ShoppingBaskets::CheckoutOrderService).to receive(:call)
+          .and_raise(StandardError.new("Unexpected error"))
+      end
+
+      it "does not catch unexpected errors" do
+        expect {
+          described_class.perform_now(
+            shopping_basket_id: basket.id,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        }.to raise_error(StandardError, "Unexpected error")
+      end
+
+      it "does not log unexpected errors with job-specific messages" do
+        allow(Rails.logger).to receive(:error)
+        begin
+          described_class.perform_now(
+            shopping_basket_id: basket.id,
+            email: email,
+            payment_token: payment_token,
+            address_params: address_params
+          )
+        rescue StandardError
+        end
+        expect(Rails.logger).not_to have_received(:error).with(/CheckoutOrderJob/)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/shopping_baskets/checkouts_spec.rb
+++ b/spec/requests/api/v2/shopping_baskets/checkouts_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V2::ShoppingBaskets::Checkouts", type: :request do
+  let(:endpoint) { "/api/v2/shopping_basket/checkout" }
+  let(:headers) { { "Authorization" => "Bearer #{basket.uuid}" } }
+
+  let(:basket) { create(:shopping_basket) }
+  let(:product) { create(:product, stock: 10, price_cents: 10_00) }
+
+  let(:payment_token) { "tok_success" }
+
+  before do
+    create(:shopping_basket_product, shopping_basket: basket, product: product, quantity: 2)
+  end
+
+  let(:valid_params) do
+    {
+      payment_token: payment_token,
+      email: "test@example.com",
+      address: {
+        line_1: "123 Calle Falsa",
+        line_2: "Apt 4",
+        city: "Montevideo",
+        state: "Montevideo",
+        zip: "11300",
+        country: "UY"
+      }
+    }
+  end
+
+  describe "POST /api/v2/checkout" do
+    context "with valid params and shopping basket" do
+      it "returns 202 Accepted" do
+        allow(CheckoutOrderJob).to receive(:perform_later)
+        post endpoint, params: valid_params, headers: headers
+        expect(response).to have_http_status :accepted
+      end
+
+      it "enqueues CheckoutOrderJob with correct parameters" do
+        expect(CheckoutOrderJob).to receive(:perform_later).with(
+          shopping_basket_id: basket.id,
+          email: "test@example.com",
+          payment_token: "tok_success",
+          address_params: hash_including(
+            "line_1" => "123 Calle Falsa",
+            "city" => "Montevideo"
+          )
+        )
+
+        post endpoint, params: valid_params, headers: headers
+      end
+
+      it "returns a message indicating checkout processing started" do
+        allow(CheckoutOrderJob).to receive(:perform_later)
+        post endpoint, params: valid_params, headers: headers
+
+        json = JSON.parse(response.body)
+        expect(json["message"]).to eq("Checkout processing started")
+      end
+    end
+
+    context "Error Handling" do
+      it "returns 400 Bad Request if params are missing" do
+        invalid_params = { payment_token: payment_token }
+
+        post endpoint, params: invalid_params, headers: headers
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## v2 API: Async Checkout Processing

This PR implements background job processing for checkout orders in the v2 API to improve scalability and reduce request-blocking time. Future work will introduce ActionCable to notify users of checkout statuses.

### Main Changes
* New Route and Controller: Added POST /api/v2/shopping_basket/checkout, which enqueues the process and returns immediately.
* CheckoutOrderJob: A background job that uses CheckoutOrderService to handle order creation.
* 202 Accepted Response: The API no longer blocks the thread; it confirms the process has started.
* Error Handling: The job handles EmptyBasketError and PaymentError, enabling automatic retries via ActiveJob.

### Rationale
The goal is to decouple heavy business logic from the HTTP request cycle. This reduces database contention and improves overall throughput during high-traffic periods.

### Testing
* Job Specs: Coverage of enqueueing, service integration, logging, and retry logic.
* Controller Specs: Validation of the 202 status and correct parameter delivery to the job.

### Additional Notes
* Backward Compatibility: The v1 endpoint remains synchronous.
* Consistency: Reuses the existing service to ensure order creation logic remains identical across versions.