### PR TITLE
Add checkout notifications via ActionCable

### DIFF
--- a/app/channels/checkout_notifications_channel.rb
+++ b/app/channels/checkout_notifications_channel.rb
@@ -1,0 +1,15 @@
+class CheckoutNotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from stream_name
+  end
+
+  def unsubscribed
+    stop_all_streams
+  end
+
+  private
+
+  def stream_name
+    "checkout_#{params[:shopping_basket_id]}"
+  end
+end

--- a/app/channels/checkout_notifications_channel.rb
+++ b/app/channels/checkout_notifications_channel.rb
@@ -1,5 +1,7 @@
 class CheckoutNotificationsChannel < ApplicationCable::Channel
   def subscribed
+    return reject unless params[:shopping_basket_id].present?
+
     stream_from stream_name
   end
 

--- a/app/controllers/api/v2/shopping_baskets/checkouts_controller.rb
+++ b/app/controllers/api/v2/shopping_baskets/checkouts_controller.rb
@@ -9,7 +9,7 @@ module Api
 
           current_shopping_basket.build_order(status: :pending).save!
           enqueue_checkout_job
-          render json: { message: "Checkout processing started" }, status: :accepted
+          render json: checkout_response, status: :accepted
         rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation
           render_checkout_already_processing
         end
@@ -32,6 +32,16 @@ module Api
               messages: [ "Checkout is already being processed" ]
             }
           }, status: :conflict
+        end
+
+        def checkout_response
+          {
+            message: "Checkout processing started",
+            notifications: {
+              channel: "CheckoutNotificationsChannel",
+              params: { shopping_basket_id: current_shopping_basket.uuid }
+            }
+          }
         end
 
         def checkout_params

--- a/app/jobs/checkout_order_job.rb
+++ b/app/jobs/checkout_order_job.rb
@@ -3,16 +3,40 @@ class CheckoutOrderJob < ApplicationJob
 
   def perform(shopping_basket_id:, email:, payment_token:, address_params:)
     shopping_basket = ShoppingBasket.find(shopping_basket_id)
+    stream_name = "checkout_#{shopping_basket.uuid}"
 
-    ::ShoppingBaskets::CheckoutOrderService.call(
+    order = ::ShoppingBaskets::CheckoutOrderService.call(
       shopping_basket: shopping_basket,
       email: email,
       payment_token: payment_token,
       address_params: address_params
     )
+
+    broadcast_completed(stream_name, order)
   rescue ::ShoppingBaskets::CheckoutOrderService::EmptyBasketError => e
     Rails.logger.error("CheckoutOrderJob failed: #{e.message} for basket #{shopping_basket_id}")
+    broadcast_failed(stream_name, "empty_basket", e.message)
   rescue ::ShoppingBaskets::CheckoutOrderService::PaymentError => e
     Rails.logger.error("CheckoutOrderJob payment failed: #{e.message} for basket #{shopping_basket_id}")
+    broadcast_failed(stream_name, "payment_required", e.message)
+  end
+
+  private
+
+  def broadcast_completed(stream_name, order)
+    order_with_products = Order.with_associations.find(order.id)
+    payload = {
+      status: "completed",
+      order: OrderBlueprint.render_as_hash(order_with_products)
+    }
+    ActionCable.server.broadcast(stream_name, payload)
+  end
+
+  def broadcast_failed(stream_name, code, message)
+    payload = {
+      status: "failed",
+      error: { code: code, message: message }
+    }
+    ActionCable.server.broadcast(stream_name, payload)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,8 +67,9 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  # Allow ActionCable connections from any origin (localhost, load tests, etc.).
+  # Required for: local frontend dev, k6 load tests. Production uses allowed_request_origins.
+  config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true

--- a/docs/API_v2.md
+++ b/docs/API_v2.md
@@ -93,3 +93,74 @@ Returns details of a specific product.
     }
     ```
   - **Status:** `404 Not Found` (if product does not exist)
+
+---
+
+## Checkout (Async)
+
+Processes the checkout asynchronously. Returns immediately with `202 Accepted` and provides WebSocket subscription details to receive completion notifications.
+
+- **Endpoint:** `POST /shopping_basket/checkout`
+- **Headers:**
+  - `Authorization: Bearer <uuid>` (required)
+- **Parameters (JSON Body):** Same as V1 (payment_token, email, address)
+- **Response:**
+  - **Status:** `202 Accepted`
+  - **Body:**
+    ```json
+    {
+      "message": "Checkout processing started",
+      "notifications": {
+        "channel": "CheckoutNotificationsChannel",
+        "params": { "shopping_basket_id": "01936e2a-..." }
+      }
+    }
+    ```
+  - **Fields:**
+    - `message`: Confirmation that checkout was queued
+    - `notifications`: Use this to subscribe to real-time updates via WebSocket
+
+### Checkout Notifications (WebSocket)
+
+Subscribe to receive checkout completion or failure in real time.
+
+- **WebSocket endpoint:** `ws://localhost:3000/cable` (replace host for other environments)
+- **Subscription:** Use the `notifications` object from the 202 response:
+
+  ```javascript
+  const { channel, params } = response.notifications;
+  consumer.subscriptions.create(
+    { channel, ...params },
+    { received: (data) => handleCheckoutResult(data) }
+  );
+  ```
+
+  Example: `{ channel: "CheckoutNotificationsChannel", shopping_basket_id: "01936e2a-..." }`
+
+- **Message formats:**
+
+  **Success (status: completed):**
+  ```json
+  {
+    "status": "completed",
+    "order": {
+      "id": "01936e2a-...",
+      "email": "user@example.com",
+      "total_price": { "cents": 2000, "currency": "USD" },
+      "order_products": [...]
+    }
+  }
+  ```
+  The `order` object matches V1 checkout response format.
+
+  **Failure (status: failed):**
+  ```json
+  {
+    "status": "failed",
+    "error": {
+      "code": "empty_basket",
+      "message": "No items available in stock."
+    }
+  }
+  ```
+  Error codes: `empty_basket`, `payment_required`

--- a/docs/API_v2.md
+++ b/docs/API_v2.md
@@ -100,10 +100,51 @@ Returns details of a specific product.
 
 Processes the checkout asynchronously. Returns immediately with `202 Accepted` and provides WebSocket subscription details to receive completion notifications.
 
+**Prerequisites:** Create a basket and add products via V1 (`POST /api/v1/shopping_basket/products`). Use the `Shopping-Basket-ID` header from the response or the basket UUID for the `Authorization` header.
+
 - **Endpoint:** `POST /shopping_basket/checkout`
 - **Headers:**
   - `Authorization: Bearer <uuid>` (required)
-- **Parameters (JSON Body):** Same as V1 (payment_token, email, address)
+- **Parameters (JSON Body):**
+  ```json
+  {
+    "payment_token": "tok_success",
+    "email": "user@example.com",
+    "address": {
+      "line_1": "123 Main St",
+      "line_2": "Apt 4B",
+      "city": "New York",
+      "state": "NY",
+      "zip": "10001",
+      "country": "US"
+    }
+  }
+  ```
+  - `payment_token`: Use `tok_success` for successful payment simulation or `tok_fail` to simulate a decline.
+- **Example:**
+  ```bash
+  # 1. Create basket and add product (V1) - save Shopping-Basket-ID from response headers
+  curl -v -X POST "http://localhost:3000/api/v1/shopping_basket/products" \
+    -H "Content-Type: application/json" \
+    -d '{"product": {"product_id": 1, "quantity": 2}}'
+
+  # 2. Checkout (V2) - use basket UUID from step 1
+  curl -v -X POST "http://localhost:3000/api/v2/shopping_basket/checkout" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <uuid-from-step-1>" \
+    -d '{
+      "payment_token": "tok_success",
+      "email": "user@example.com",
+      "address": {
+        "line_1": "123 Main St",
+        "line_2": "Apt 4B",
+        "city": "New York",
+        "state": "NY",
+        "zip": "10001",
+        "country": "US"
+      }
+    }'
+  ```
 - **Response:**
   - **Status:** `202 Accepted`
   - **Body:**
@@ -112,7 +153,9 @@ Processes the checkout asynchronously. Returns immediately with `202 Accepted` a
       "message": "Checkout processing started",
       "notifications": {
         "channel": "CheckoutNotificationsChannel",
-        "params": { "shopping_basket_id": "01936e2a-..." }
+        "params": {
+          "shopping_basket_id": "019c68f2-80b8-7179-b9c5-805060290f97"
+        }
       }
     }
     ```

--- a/spec/channels/checkout_notifications_channel_spec.rb
+++ b/spec/channels/checkout_notifications_channel_spec.rb
@@ -3,30 +3,37 @@ require "rails_helper"
 RSpec.describe CheckoutNotificationsChannel, type: :channel do
   let(:shopping_basket_id) { SecureRandom.uuid }
 
-  before do
-    stub_connection
-  end
+  before { stub_connection }
 
   describe "#subscribed" do
-    it "subscribes to the stream for the given shopping_basket_id" do
-      subscribe(shopping_basket_id: shopping_basket_id)
+    context "with valid shopping_basket_id" do
+      before { subscribe(shopping_basket_id:) }
 
-      expect(subscription).to be_confirmed
-      expect(subscription).to have_stream_from("checkout_#{shopping_basket_id}")
+      it "subscribes to the stream for the given shopping_basket_id" do
+        expect(subscription).to be_confirmed
+        expect(subscription).to have_stream_from("checkout_#{shopping_basket_id}")
+      end
+
+      it "subscribes to different streams for different basket IDs" do
+        other_id = SecureRandom.uuid
+        expect(subscription).to have_stream_from("checkout_#{shopping_basket_id}")
+        expect(subscription).not_to have_stream_from("checkout_#{other_id}")
+      end
     end
 
-    it "subscribes to different streams for different basket IDs" do
-      other_id = SecureRandom.uuid
-      subscribe(shopping_basket_id: shopping_basket_id)
+    context "when shopping_basket_id is missing" do
+      it "rejects subscription" do
+        subscribe(shopping_basket_id: nil)
 
-      expect(subscription).to have_stream_from("checkout_#{shopping_basket_id}")
-      expect(subscription).not_to have_stream_from("checkout_#{other_id}")
+        expect(subscription).to be_rejected
+      end
     end
   end
 
   describe "#unsubscribed" do
+    before { subscribe(shopping_basket_id:) }
+
     it "stops all streams when unsubscribed" do
-      subscribe(shopping_basket_id: shopping_basket_id)
       unsubscribe
 
       expect(subscription).not_to have_streams

--- a/spec/channels/checkout_notifications_channel_spec.rb
+++ b/spec/channels/checkout_notifications_channel_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe CheckoutNotificationsChannel, type: :channel do
+  let(:shopping_basket_id) { SecureRandom.uuid }
+
+  before do
+    stub_connection
+  end
+
+  describe "#subscribed" do
+    it "subscribes to the stream for the given shopping_basket_id" do
+      subscribe(shopping_basket_id: shopping_basket_id)
+
+      expect(subscription).to be_confirmed
+      expect(subscription).to have_stream_from("checkout_#{shopping_basket_id}")
+    end
+
+    it "subscribes to different streams for different basket IDs" do
+      other_id = SecureRandom.uuid
+      subscribe(shopping_basket_id: shopping_basket_id)
+
+      expect(subscription).to have_stream_from("checkout_#{shopping_basket_id}")
+      expect(subscription).not_to have_stream_from("checkout_#{other_id}")
+    end
+  end
+
+  describe "#unsubscribed" do
+    it "stops all streams when unsubscribed" do
+      subscribe(shopping_basket_id: shopping_basket_id)
+      unsubscribe
+
+      expect(subscription).not_to have_streams
+    end
+  end
+end

--- a/spec/requests/api/v2/shopping_baskets/checkouts_spec.rb
+++ b/spec/requests/api/v2/shopping_baskets/checkouts_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe "Api::V2::ShoppingBaskets::Checkouts", type: :request do
         json = JSON.parse(response.body)
         expect(json["message"]).to eq("Checkout processing started")
       end
+
+      it "returns notifications object with channel and params for WebSocket subscription" do
+        allow(CheckoutOrderJob).to receive(:perform_later)
+        post endpoint, params: valid_params, headers: headers
+
+        json = JSON.parse(response.body)
+        expect(json["notifications"]).to eq(
+          "channel" => "CheckoutNotificationsChannel",
+          "params" => { "shopping_basket_id" => basket.uuid }
+        )
+      end
     end
 
     context "Error Handling" do


### PR DESCRIPTION
Closes #19

Implements real-time checkout notifications via ActionCable so clients know when async checkout completes or fails.

**Changes:**
- Add CheckoutNotificationsChannel (stream by shopping_basket_id)
- Broadcast from CheckoutOrderJob on success and failure
- Enrich 202 response with notifications object (channel + params)
- Document WebSocket endpoint and message formats in API_v2.md
- Enable ActionCable config for development (local testing, load tests)
- Add curl examples and full flow documentation