### PR TITLE
Add V2 basket endpoints and API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,16 @@ rails dev:cache
 | `GET` | `/api/v1/products` | List products (offset pagination, 20/page) |
 | `GET` | `/api/v2/products` | List products (keyset pagination, 20/page) |
 | `GET` | `/api/v1/products/:id` | Product details |
+| `GET` | `/api/v2/products/:id` | Product details (same as V1) |
 
 ### Basket
 
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/v1/shopping_basket` | View current basket |
+| `GET` | `/api/v2/shopping_basket` | View current basket (same as V1) |
 | `POST` | `/api/v1/shopping_basket/products` | Add/update item in basket |
+| `POST` | `/api/v2/shopping_basket/products` | Add/update item in basket (same as V1) |
 
 ### Checkout
 

--- a/app/controllers/api/v2/shopping_baskets/shopping_basket_products_controller.rb
+++ b/app/controllers/api/v2/shopping_baskets/shopping_basket_products_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V2
+    module ShoppingBaskets
+      class ShoppingBasketProductsController < V1::ShoppingBaskets::ShoppingBasketProductsController
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/shopping_baskets_controller.rb
+++ b/app/controllers/api/v2/shopping_baskets_controller.rb
@@ -1,0 +1,6 @@
+module Api
+  module V2
+    class ShoppingBasketsController < V1::ShoppingBasketsController
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **V2 basket controllers**: Add `ShoppingBasketsController` and `ShoppingBasketProductsController` for V2 (inherit from V1, same behavior)
- **API docs**: Add Shopping Baskets section to `API_v2.md` with curl examples from real responses
- **Checkout flow**: Update examples to use V2 basket endpoints for a complete V2 flow
- **README**: Add V2 basket and product endpoints to API table